### PR TITLE
MGDOBR-896: Add bom and build-parent - project scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+target/
+/local
+
+*.iml
+**/.idea

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>com.redhat.services.ffm</groupId>
+    <artifactId>factorized-fleet-manager</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>bom</artifactId>
+  <packaging>pom</packaging>
+  <name>Factorized Fleet Manager :: BOM</name>
+
+  <dependencyManagement>
+    <dependencies>
+    <!-- Modules to be added here-->
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/build-parent/README.md
+++ b/build-parent/README.md
@@ -1,0 +1,13 @@
+# Build Parent Module
+
+This module holds the Maven BOM file parent of all other modules. It's used to configure the project build process.
+
+## Restrict Imports Enforce Rule
+
+We rely on [restrict-imports-enforcer-rule](https://github.com/skuzzle/restrict-imports-enforcer-rule) to restrict some
+imports in our code base.
+
+Even though we do not ban a given dependency, some use cases require us to ban a class or package from a dependency.
+
+If you need to add more rules to the plugin configuration, please see
+their [README](https://github.com/skuzzle/restrict-imports-enforcer-rule/blob/master/README.md) for instructions.

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -34,9 +34,9 @@
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
     <version.install.plugin>2.5.2</version.install.plugin>
-    <kogito.formatter.version>1.11.0.Final</kogito.formatter.version>
-    <formatter.plugin.version>2.13.0</formatter.plugin.version>
-    <impsort.plugin.version>1.5.0</impsort.plugin.version>
+    <quarkus.formatter.version>2.7.0.Final</quarkus.formatter.version>
+    <formatter.plugin.version>2.18.0</formatter.plugin.version>
+    <impsort.plugin.version>1.6.2</impsort.plugin.version>
     <version.enforcer.plugin>3.0.0</version.enforcer.plugin>
     <restrict-imports.plugin.version>1.4.0</restrict-imports.plugin.version>
 
@@ -198,12 +198,14 @@
           <version>${formatter.plugin.version}</version>
           <dependencies>
             <dependency>
-              <artifactId>kogito-ide-config</artifactId>
-              <groupId>org.kie.kogito</groupId>
-              <version>${kogito.formatter.version}</version>
+              <artifactId>quarkus-ide-config</artifactId>
+              <groupId>io.quarkus</groupId>
+              <version>${quarkus.formatter.version}</version>
             </dependency>
           </dependencies>
           <configuration>
+            <!-- store outside of target to speed up formatting when mvn clean is used -->
+            <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
             <configFile>eclipse-format.xml</configFile>
             <lineEnding>LF</lineEnding>
             <skip>${formatter.skip}</skip>
@@ -221,11 +223,10 @@
           <artifactId>impsort-maven-plugin</artifactId>
           <version>${impsort.plugin.version}</version>
           <configuration>
-            <!-- keep in sync with kogito-ide-config/src/main/resources/eclipse.importorder -->
-            <groups>java.,javax.,org.,com.,io.</groups>
+            <!-- store outside of target to speed up formatting when mvn clean is used -->
+            <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
+            <groups>java.,javax.,jakarta.,org.,com.</groups>
             <staticGroups>*</staticGroups>
-            <staticAfter>true</staticAfter>
-            <!-- keep in sync with the formatter-maven-plugin -->
             <skip>${formatter.skip}</skip>
             <removeUnused>true</removeUnused>
           </configuration>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1,0 +1,288 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>factorized-fleet-manager</artifactId>
+    <groupId>com.redhat.services.ffm</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
+
+  <artifactId>build-parent</artifactId>
+  <name>Factorized Fleet Manager :: Build Parent</name>
+  <description>Factorized Fleet Manager Dependency Management Project BOM</description>
+
+  <properties>
+
+    <maven.compiler.release>11</maven.compiler.release>
+    <version.maven>3.6.2</version.maven>
+    <version.jdk>11</version.jdk>
+
+    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <version.dependency.plugin>2.8</version.dependency.plugin>
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+    <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+    <quarkus-amazon-services.version>1.0.3</quarkus-amazon-services.version>
+    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin> <!-- minimum required by JUnit 5 -->
+    <version.install.plugin>2.5.2</version.install.plugin>
+    <kogito.formatter.version>1.11.0.Final</kogito.formatter.version>
+    <formatter.plugin.version>2.13.0</formatter.plugin.version>
+    <impsort.plugin.version>1.5.0</impsort.plugin.version>
+    <version.enforcer.plugin>3.0.0</version.enforcer.plugin>
+    <restrict-imports.plugin.version>1.4.0</restrict-imports.plugin.version>
+
+    <formatter.skip>false</formatter.skip>
+    <formatter.goal>format</formatter.goal>
+    <impsort.goal>sort</impsort.goal>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.redhat.services.ffm</groupId>
+        <artifactId>bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+          <groupId>${quarkus.platform.group-id}</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${quarkus.platform.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${quarkus.platform.version}</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${version.compiler.plugin}</version>
+          <configuration>
+            <showDeprecation>true</showDeprecation>
+            <showWarnings>true</showWarnings>
+            <release>${maven.compiler.release}</release>
+            <compilerArgs>
+              <arg>-Xlint:unchecked</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${version.install.plugin}</version>
+          <executions>
+            <execution>
+              <id>default-install</id>
+              <phase>install</phase>
+              <goals>
+                <goal>install</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${version.dependency.plugin}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${version.surefire.plugin}</version>
+          <configuration>
+            <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
+            <systemPropertyVariables>
+              <apple.awt.UIElement>true</apple.awt.UIElement>
+              <org.uberfire.nio.git.daemon.enabled>false</org.uberfire.nio.git.daemon.enabled>
+              <org.uberfire.nio.git.ssh.enabled>false</org.uberfire.nio.git.ssh.enabled>
+              <org.uberfire.sys.repo.monitor.disabled>true</org.uberfire.sys.repo.monitor.disabled>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${version.surefire.plugin}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${version.enforcer.plugin}</version>
+          <dependencies>
+            <dependency>
+              <groupId>de.skuzzle.enforcer</groupId>
+              <artifactId>restrict-imports-enforcer-rule</artifactId>
+              <version>${restrict-imports.plugin.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>enforce-versions</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>${version.maven}</version>
+                  </requireMavenVersion>
+                  <requireJavaVersion>
+                    <version>${version.jdk}</version>
+                  </requireJavaVersion>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+            <execution>
+              <id>check-assert-imports</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <RestrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Use AssertJ for Assertions instead of JUnit</reason>
+                    <bannedImports>
+                      <bannedImport>static org.junit.jupiter.api.Assertions.*</bannedImport>
+                      <bannedImport>org.junit.jupiter.api.Assertions</bannedImport>
+                      <bannedImport>static org.junit.Assert.*</bannedImport>
+                      <bannedImport>org.junit.Assert</bannedImport>
+                    </bannedImports>
+                  </RestrictImports>
+                  <RestrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Use AssertJ for Assertions instead of Hamcrest</reason>
+                    <bannedImports>
+                      <bannedImport>static org.hamcrest.MatcherAssert.*</bannedImport>
+                      <bannedImport>org.hamcrest.MatcherAssert</bannedImport>
+                    </bannedImports>
+                  </RestrictImports>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>net.revelc.code.formatter</groupId>
+          <artifactId>formatter-maven-plugin</artifactId>
+          <version>${formatter.plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <artifactId>kogito-ide-config</artifactId>
+              <groupId>org.kie.kogito</groupId>
+              <version>${kogito.formatter.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <configFile>eclipse-format.xml</configFile>
+            <lineEnding>LF</lineEnding>
+            <skip>${formatter.skip}</skip>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>${formatter.goal}</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>net.revelc.code</groupId>
+          <artifactId>impsort-maven-plugin</artifactId>
+          <version>${impsort.plugin.version}</version>
+          <configuration>
+            <!-- keep in sync with kogito-ide-config/src/main/resources/eclipse.importorder -->
+            <groups>java.,javax.,org.,com.,io.</groups>
+            <staticGroups>*</staticGroups>
+            <staticAfter>true</staticAfter>
+            <!-- keep in sync with the formatter-maven-plugin -->
+            <skip>${formatter.skip}</skip>
+            <removeUnused>true</removeUnused>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>${impsort.goal}</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>net.revelc.code.formatter</groupId>
+        <artifactId>formatter-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.revelc.code</groupId>
+        <artifactId>impsort-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <!-- Fail the build if code does not follow the standards. -->
+      <id>validate-formatting</id>
+      <activation>
+        <property>
+          <name>validate-formatting</name>
+        </property>
+      </activation>
+      <properties>
+        <formatter.skip>false</formatter.skip>
+        <formatter.goal>validate</formatter.goal>
+        <impsort.goal>check</impsort.goal>
+      </properties>
+    </profile>
+    <profile>
+      <id>quickly</id>
+      <activation>
+        <property>
+          <name>quickly</name>
+        </property>
+      </activation>
+      <properties>
+        <formatter.skip>true</formatter.skip>
+        <skipITs>true</skipITs>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.redhat.services.ffm</groupId>
+  <artifactId>factorized-fleet-manager</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Factorized Fleet Manager</name>
+  <description>Parent module for factorized fleet manager</description>
+
+  <inceptionYear>2022</inceptionYear>
+  <organization>
+    <name>Red Hat</name>
+    <url>https://www.redhat.com/</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modules>
+    <module>build-parent</module>
+    <module>bom</module>
+  </modules>
+
+</project>


### PR DESCRIPTION
This PR aims to add: 

1) The initial multi-module maven project setup
2) setup of the formatter and the impsort plugings (we rely on the `quarkus-ide-config` -> the same formatting rules of quarkus)
3) setup of the `validation` profile to check the code format and impsort. Setup of the `quickly` profile
4) gitignore
5) Use AssertJ for Assertions instead of JUnit -> rule enforced by a plugin
6) Use AssertJ for Assertions instead of Hamcrest -> rule enforced by a plugin